### PR TITLE
corrigida tag PHP abreviada que impedia a exibição do conteudo

### DIFF
--- a/content-video.php
+++ b/content-video.php
@@ -11,66 +11,54 @@
 ?>
 
 	<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-		<?php if ( is_sticky() && is_home() && ! is_paged() ) : ?>
+	<?php
+	if( is_sticky() && is_home() && ! is_paged() ){
+		?>
 		<div class="featured-post">
 			<?php _e( 'Featured post', 'twentytwelve' ); ?>
 		</div>
-		<?php endif; ?>
-		<!-- <header class="entry-header">
-			<?php the_post_thumbnail(); ?>
-			<?php edit_post_link( __( 'Edit', 'twentytwelve' ), '<span class="edit-link">', '</span>' ); ?>
-			</header> -->
-
-		<?php if ( is_search() ) : // Only display Excerpts for Search ?>
+		<?php
+	}
+	if( is_search() ){
+		?>
 		<div class="entry-summary">
 			<?php the_excerpt(); ?>
 		</div><!-- .entry-summary -->
-		<?php else : ?>
+		<?php
+	}
+	else{
+		?>
 		<div class="entry-content">
-			<?php 
-				$video_url = get_post_meta($post->ID, "video_url", TRUE);
-				if ( $video_url ) {
-					render_video_url($video_url);
-				}
-				else { ?>
-					<div class="video-placeholder"></div>
-				<? }
+		<?php 
+		$video_url = get_post_meta($post->ID, "video_url", TRUE);
+		if( $video_url ){
+			render_video_url($video_url);
+		}
+		else{
 			?>
-
-			<?php if ( is_single() ) : ?>
-			<h1 class="entry-title"><?php the_title(); ?></h1>
-			<?php else : ?>
+			<div class="video-placeholder"></div>
+			<?php
+		}
+		if( is_single() ){
+			?>
+			<h1 class="entry-title">
+				<?php the_title(); ?>
+			</h1>
+			<?php
+		}
+		else{
+			?>
 			<h1 class="entry-title">
 				<a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a>
 			</h1>
-			<?php endif; // is_single() ?>
-
-			<?php the_content( __( 'Continue reading <span class="meta-nav">&rarr;</span>', 'twentytwelve' ) ); ?>
-			<?php wp_link_pages( array( 'before' => '<div class="page-links">' . __( 'Pages:', 'twentytwelve' ), 'after' => '</div>' ) ); ?>
-			<?php the_tags( "TAGS: ", "," ); ?> 
+			<?php
+		}
+		the_content( __( 'Continue reading <span class="meta-nav">&rarr;</span>', 'twentytwelve' ) );
+		wp_link_pages( array( 'before' => '<div class="page-links">' . __( 'Pages:', 'twentytwelve' ), 'after' => '</div>' ) );
+		the_tags( "TAGS: ", "," );
+		?>
 		</div><!-- .entry-content -->
-		<?php endif; ?>
-
-		<footer class="entry-meta">
-			<?php if ( is_single() ) {
-
-        		$related_posts = get_related_post_content($post->ID);
-       			if ($related_posts) {
-            		foreach ($related_posts as $r) {
-	            		?>
-	                	<div class="small-grid format-<?php echo get_post_format( $r->ID ); ?>">   
-	                	<?php if ( get_the_post_thumbnail( $r->ID, 'thumbnail' ) != "" ) {
-	                        echo get_the_post_thumbnail( $r->ID, 'thumbnail' );
-	                    }
-	                    else { ?>
-	                        <img src='<?php echo  get_stylesheet_directory_uri() . '/images/' . get_post_format( $r->ID ) .'.png' ?>' width="98" height="77" />
-	                    <?php } ?>
-	                    <a href="<?php echo $r->guid; ?>" rel="bookmark"><?php echo $r->post_title; ?></a>
-	                	</div>
-	                	<?php
-            		}
-   				}
-			}
-    		?>
-		</footer><!-- .entry-meta -->
+		<?php
+	}
+	?>
 	</article><!-- #post -->

--- a/front-page.php
+++ b/front-page.php
@@ -15,27 +15,20 @@
 get_header(); ?>
 
 	<div id="primary" class="site-content">
-		<div id="content" role="main">
         <?php while ( have_posts() ) : the_post(); ?>
-			   <!-- <iframe src="//player.vimeo.com/video/78694247?portrait=0&title=0&=badge=0&byline=0&color=93101c" width="622" height="350" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe> -->
-			   <a href="https://www.facebook.com/tvamericalatina2/app_340216556126485"><img src="<?php echo get_stylesheet_directory_uri(); ?>/images/tal.jpg" /></a>
+		<div id="content" role="main">
+        <?php the_content(); ?>
 		</div><!-- #content -->
+        <?php endwhile; // end of the loop. ?>
 	</div><!-- #primary -->
     
-    <?php if ( is_front_page() ) : // Only display Excerpts for Search ?>    
+    <?php if ( is_front_page() ) : // Only display Excerpts for Search ?>
     <div id="secondary" class="widget-area" role="complementary">
-            <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-            <div class="entry-summary">
-                    <?php the_excerpt(); ?>
-            </div><!-- .entry-summary -->        
-            <div id="mapa-banner">
-                <a href="<?php echo esc_url( home_url( '/' ) ); ?>mapa">
-                    <b>Veja o mapa</b>
-                    <img src="<?php echo get_stylesheet_directory_uri(); ?>/images/mapa-banner.png" style="width:250px;border:1px solid black;margin-top:5px;" />
-                </a>
-            </div>
-            </article>
+        <?php if ( is_active_sidebar( 'home_left_sidebar' ) ) : ?>
+        <div id="primary-sidebar" class="primary-sidebar widget-area" role="complementary">
+            <?php dynamic_sidebar( 'home_left_sidebar' ); ?>
+        </div><!-- #primary-sidebar -->
+        <?php endif; ?>
     </div>
     <?php endif; ?>                
-     <?php endwhile; // end of the loop. ?>
 <?php get_footer(); ?>

--- a/functions.php
+++ b/functions.php
@@ -18,6 +18,25 @@ add_action( 'after_setup_theme', 'childtheme_formats', 11 );
 function childtheme_formats(){
     add_theme_support( 'post-formats', array( 'video', 'image', 'link', 'status', 'quote' ) );
 }
+
+/**
+ * Register our sidebars and widgetized areas.
+ *
+ */
+function habitar_widgets_init() {
+
+    register_sidebar( array(
+        'name'          => __('Barra Lateral da Home'),
+        'id'            => 'home_left_sidebar',
+        'before_widget' => '<div>',
+        'after_widget'  => '</div>',
+        'before_title'  => '<h2 class="rounded">',
+        'after_title'   => '</h2>',
+    ) );
+
+}
+add_action( 'widgets_init', 'habitar_widgets_init' );
+
 //Get Video ID
 
 function render_video_url( $url ) {

--- a/style.css
+++ b/style.css
@@ -272,3 +272,14 @@ aside.cat-historias img {
 .small-grid a {
     line-height: 1;
 }
+/* Home */
+body.home .widget-area > .widget-area{
+    width: 100%;
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+body.home .widget-area h1,
+body.home .widget-area h2 {
+    margin-top: 2px;
+    margin-bottom: 3px;
+}


### PR DESCRIPTION
Uma correção pra um erro bobo num dos templates do tema: Uma tag PHP aberta na versão abreviada (<?, sem o PHP). Bobo mas que deixou sem conteúdo o site todo depois da mudança pro php-fpm.
